### PR TITLE
Upgrade Nginx to 1.10 (stable)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 nginx_common_packages:
-  - http://nginx.org/packages/rhel/7/x86_64/RPMS/nginx-1.10.0-1.el7.ngx.x86_64.rpm
+  - http://nginx.org/packages/centos/7/x86_64/RPMS/nginx-1.10.0-1.el7.ngx.x86_64.rpm
 
 nginx_worker_processes: 2
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 nginx_common_packages:
-  - http://nginx.org/packages/centos/7/x86_64/RPMS/nginx-1.8.1-1.el7.ngx.x86_64.rpm
+  - http://nginx.org/packages/rhel/7/x86_64/RPMS/nginx-1.10.0-1.el7.ngx.x86_64.rpm
 
 nginx_worker_processes: 2
 


### PR DESCRIPTION
Update required no changes to config files (`nginx -t` passed on all hosts and static/PHP/reverse-proxy websites continue to work as before).

[New features/improvements](https://www.nginx.com/blog/nginx-1-10-1-11-released/):

 * HTTP/2 support
 * The new stream module
 * Support for dynamic modules
 * The new slice module
 * SO_REUSEPORT support
 * Better handling of idempotent requests
 * AIO and thread pools
 * Improved cache management
 * Improved CPU affinity
 * Include directive
 * Support for HEAD caching
 * SYSLOG extensions
 * The realip module
 * Upstream conect times
 * Memcached module
 * Shared data for upstreams
 * Mail proxy server