### PR TITLE
Update to 1.10.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 nginx_common_packages:
-  - http://nginx.org/packages/centos/7/x86_64/RPMS/nginx-1.10.1-1.el7.ngx.x86_64.rpm
+  - https://nginx.org/packages/centos/7/x86_64/RPMS/nginx-1.10.2-1.el7.ngx.x86_64.rpm
 
 nginx_worker_processes: 2
 


### PR DESCRIPTION
Is not critical but solves some bugs and support the latest OpenSSL. Changes listed here: http://nginx.org/en/CHANGES-1.10